### PR TITLE
Implement option to download all profiles in just one folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Options:
   -v, --version         Display program version
   -o, --output [path]   Output directory
   -f, --force           Force creation of output directory
+  -O, --open            Open output folders when finished
+  -uf, --unifolder      Downloads the contents in the parent folder, instead of subdirectories.
   -q, --queue <number>  Set how many items to get from Instagram API (default: 12)
   -l, --limit <number>  Set how many items to download in total
   -ns, --no-stories     Disable stories download

--- a/src/config.js
+++ b/src/config.js
@@ -24,6 +24,18 @@ const config = {
 			defaultValue: false
 		},
 		{
+			option: "open",
+			alternative: "O",
+			description: "Open output folders when finished",
+			defaultValue: false
+		},
+		{
+			option: "unifolder",
+			alternative: "uf",
+			description: "Downloads the contents in the parent folder, instead of subdirectories.",
+			defaultValue: false
+		},
+		{
 			option: "queue",
 			alternative: "q",
 			description: "Set how many items to get from Instagram API",


### PR DESCRIPTION
- Add option to download all profiles in just one folder, instead of creating subdirectories
- Add option to open the downloads folder when the code finishes